### PR TITLE
updates to include ray shutdown pass in atm_interp

### DIFF
--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -131,6 +131,7 @@ def analytical_line(
             atm_band_names=fm.RT.statevec_names,
             nneighbors=n_atm_neighbors,
             gaussian_smoothing_sigma=smoothing_sigma,
+            ray_autoshutdown=False,
         )
 
     rdn_ds = envi.open(envi_header(rdn_file))
@@ -180,16 +181,16 @@ def analytical_line(
         n_workers = multiprocessing.cpu_count()
 
     wargs = [
-        config,
+        ray.put(config),
         ray.put(fm),
-        atm_file,
-        analytical_state_file,
-        analytical_state_unc_file,
-        rdn_file,
-        loc_file,
-        obs_file,
-        loglevel,
-        logfile,
+        ray.put(atm_file),
+        ray.put(analytical_state_file),
+        ray.put(analytical_state_unc_file),
+        ray.put(rdn_file),
+        ray.put(loc_file),
+        ray.put(obs_file),
+        ray.put(loglevel),
+        ray.put(logfile),
     ]
     workers = ray.util.ActorPool([Worker.remote(*wargs) for _ in range(n_workers)])
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -587,9 +587,10 @@ def apply_oe(args):
 
         # Run modtran retrieval
         logging.info("Running ISOFIT with full LUT")
-        retrieval_full = isofit.Isofit(
-            paths.isofit_full_config_path, level="INFO", logfile=args.log_file
-        )
+        full_args = {'level':"INFO", 'logfile':args.log_file}
+        if use_superpixels and (args.empirical_line or args.analytical_line):
+            full_args['autoshutdown']  = False
+        retrieval_full = isofit.Isofit(paths.isofit_full_config_path, **full_args)
         retrieval_full.run()
         del retrieval_full
 

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -236,6 +236,7 @@ def atm_interpolation(
     logfile: str = None,
     n_cores: int = -1,
     gaussian_smoothing_sigma: list = None,
+    ray_autoshutdown: bool = True
 ) -> None:
     """
     Perform an empirical line interpolation and gaussian smoothing to atmospheric parameters.
@@ -252,6 +253,7 @@ def atm_interpolation(
         logfile:                  logging file
         n_cores:                  number of cores to run on
         gaussian_smoothing_sigma: sigma value to apply to gaussian smoothing of atmospheric parameters
+        ray_autoshutdown:         Enables calling ray.shutdown() on object deletion
     Returns:
         None
     """
@@ -366,4 +368,5 @@ def atm_interpolation(
 
     atm_img = atm_img.transpose((0, 2, 1))
     write_bil_chunk(atm_img, output_atm_file, 0, atm_img.shape)
-    ray.shutdown()
+    if ray_autoshutdown:
+        ray.shutdown()


### PR DESCRIPTION
Add in similar shutdown bypass for the second ISOFIT call in apply_oe if empirical_line or analytical_line is to be called.