### PR TITLE
Consolidate ray.shutdown using atexit

### DIFF
--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -27,8 +27,10 @@ __version__ = importlib.metadata.version(__package__ or __name__)
 
 warnings_enabled = False
 
+import atexit
 import logging
 import os
+import signal
 
 Logger = logging.getLogger("isofit")
 
@@ -39,3 +41,16 @@ if os.environ.get("ISOFIT_DEBUG"):
     from .wrappers import ray
 else:
     import ray
+
+
+def shutdown_ray():
+    try:
+        ray.shutdown()
+    except:
+        pass
+
+
+# Auto call ray.shutdown when the python interpreter exits
+atexit.register(shutdown_ray)
+signal.signal(signal.SIGINT, shutdown_ray)  # ctrl+C
+signal.signal(signal.SIGTERM, shutdown_ray)  # kill

--- a/isofit/__init__.py
+++ b/isofit/__init__.py
@@ -45,12 +45,13 @@ else:
 
 def shutdown_ray():
     try:
-        ray.shutdown()
+        ray.shutdown(_exiting_interpreter=True)
     except:
         pass
 
 
 # Auto call ray.shutdown when the python interpreter exits
+# ray itself also implements this, but there's no harm in calling it twice
 atexit.register(shutdown_ray)
 signal.signal(signal.SIGINT, shutdown_ray)  # ctrl+C
 signal.signal(signal.SIGTERM, shutdown_ray)  # kill

--- a/isofit/core/isofit.py
+++ b/isofit/core/isofit.py
@@ -43,10 +43,9 @@ class Isofit:
         config_file: isofit configuration file in JSON or YAML format
         level: logging level (ERROR, WARNING, INFO, DEBUG)
         logfile: file to write output logs to
-        autoshutdown: Enables calling ray.shutdown() on object deletion
     """
 
-    def __init__(self, config_file, level="INFO", logfile=None, autoshutdown=True):
+    def __init__(self, config_file, level="INFO", logfile=None):
         # Explicitly set the number of threads to be 1, so we more effectively
         # run in parallel
         os.environ["MKL_NUM_THREADS"] = "1"
@@ -86,19 +85,9 @@ class Isofit:
         ):
             rayargs["num_cpus"] = self.config.implementation.n_cores
 
-        self.autoshutdown = autoshutdown
         ray_initiate(rayargs)
 
         self.workers = None
-
-    def __del__(self):
-        if self.autoshutdown:
-            try:
-                ray.shutdown()
-                self.workers = None
-            except:
-                logging.error("Isofit Object Deletion unsuccessful")
-                return
 
     def run(self, row_column=None):
         """

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -17,7 +17,6 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 
-import atexit
 import logging
 import multiprocessing
 import os
@@ -172,7 +171,6 @@ def analytical_line(
     }
 
     ray_initiate(ray_dict)
-    atexit.register(ray.shutdown)
 
     n_workers = n_cores
 
@@ -208,7 +206,6 @@ def analytical_line(
         f"{round(rdns[0]*rdns[1]/total_time,4)} spectra/s, "
         f"{round(rdns[0]*rdns[1]/total_time/n_workers,4)} spectra/s/core"
     )
-    ray.shutdown()
 
 
 @ray.remote(num_cpus=1)

--- a/isofit/utils/analytical_line.py
+++ b/isofit/utils/analytical_line.py
@@ -178,16 +178,19 @@ def analytical_line(
         n_workers = multiprocessing.cpu_count()
 
     wargs = [
-        config,
-        ray.put(fm),
-        atm_file,
-        analytical_state_file,
-        analytical_state_unc_file,
-        rdn_file,
-        loc_file,
-        obs_file,
-        loglevel,
-        logfile,
+        ray.put(obj)
+        for obj in (
+            config,
+            fm,
+            atm_file,
+            analytical_state_file,
+            analytical_state_unc_file,
+            rdn_file,
+            loc_file,
+            obs_file,
+            loglevel,
+            logfile,
+        )
     ]
     workers = ray.util.ActorPool([Worker.remote(*wargs) for _ in range(n_workers)])
 

--- a/isofit/utils/apply_oe.py
+++ b/isofit/utils/apply_oe.py
@@ -488,7 +488,6 @@ def apply_oe(args):
                 paths.h2o_config_path,
                 level="INFO",
                 logfile=args.log_file,
-                autoshutdown=False,
             )
             retrieval_h2o.run()
             del retrieval_h2o

--- a/isofit/utils/atm_interpolation.py
+++ b/isofit/utils/atm_interpolation.py
@@ -17,7 +17,6 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 #
-import atexit
 import logging
 import time
 from typing import List
@@ -299,7 +298,6 @@ def atm_interpolation(
     # Initialize ray cluster
     start_time = time.time()
     ray_initiate({"ignore_reinit_error": True, "local_mode": n_cores == 1})
-    atexit.register(ray.shutdown)
 
     n_ray_cores = int(ray.available_resources()["CPU"])
     n_cores = min(n_ray_cores, n_input_lines)
@@ -366,4 +364,3 @@ def atm_interpolation(
 
     atm_img = atm_img.transpose((0, 2, 1))
     write_bil_chunk(atm_img, output_atm_file, 0, atm_img.shape)
-    ray.shutdown()

--- a/isofit/utils/empirical_line.py
+++ b/isofit/utils/empirical_line.py
@@ -18,7 +18,6 @@
 # Author: David R Thompson, david.r.thompson@jpl.nasa.gov
 #
 
-import atexit
 import logging
 import time
 from types import SimpleNamespace
@@ -555,7 +554,6 @@ def empirical_line(
         rayargs["num_cpus"] = n_cores
 
     ray_initiate(rayargs)
-    atexit.register(ray.shutdown)
 
     n_ray_cores = ray.available_resources()["CPU"]
     n_cores = min(n_ray_cores, n_input_lines)

--- a/isofit/utils/ewt_from_reflectance.py
+++ b/isofit/utils/ewt_from_reflectance.py
@@ -17,7 +17,6 @@
 # ISOFIT: Imaging Spectrometer Optimal FITting
 # Author: Philip G. Brodrick, philip.brodrick@jpl.nasa.gov
 
-import atexit
 import logging
 import multiprocessing
 import os
@@ -99,7 +98,6 @@ def main(args: SimpleNamespace) -> None:
     }
 
     ray.init(**rayargs)
-    atexit.register(ray.shutdown)
 
     line_breaks = np.linspace(0, rfls[0], n_workers, dtype=int)
     line_breaks = [

--- a/isofit/utils/extractions.py
+++ b/isofit/utils/extractions.py
@@ -18,7 +18,6 @@
 # Author: David R Thompson, david.r.thompson@jpl.nasa.gov
 #
 
-import atexit
 import logging
 
 import numpy as np
@@ -176,7 +175,6 @@ def extractions(
         rayargs["num_cpus"] = n_cores
 
     ray_initiate(rayargs)
-    atexit.register(ray.shutdown)
 
     labelid = ray.put(labels)
     jobs = []
@@ -197,7 +195,6 @@ def extractions(
         if ret is not None:
             out[idx, :, 0] = ret
     del rreturn
-    ray.shutdown()
 
     meta["lines"] = str(nout)
     meta["bands"] = str(nb)
@@ -214,4 +211,3 @@ def extractions(
         type = "float64"
 
     write_bil_chunk(out, out_file, 0, out.shape, dtype=type)
-    ray.shutdown()

--- a/isofit/utils/segment.py
+++ b/isofit/utils/segment.py
@@ -18,7 +18,6 @@
 # Author: David R Thompson, david.r.thompson@jpl.nasa.gov
 #
 
-import atexit
 import logging
 
 import numpy as np
@@ -209,7 +208,6 @@ def segment(
         rayargs["num_cpus"] = n_cores
 
     ray_initiate(rayargs)
-    atexit.register(ray.shutdown)
 
     # Iterate through image "chunks," segmenting as we go
     all_labels = np.zeros((nl, ns), dtype=np.int64)
@@ -254,7 +252,6 @@ def segment(
                 next_label += 1
             all_labels[lstart:lend, ...] = ordered_chunk_labels
     del rreturn
-    ray.shutdown()
 
     # Final file I/O
     logging.debug("Writing output")
@@ -271,4 +268,3 @@ def segment(
     lbl_mm = lbl_img.open_memmap(interleave="source", writable=True)
     lbl_mm[:, :] = np.array(all_labels, dtype=np.float32).reshape((nl, 1, ns))
     del lbl_mm
-    ray.shutdown()


### PR DESCRIPTION
Implements `atexit` in `isofit.__init__` to call `ray.shutdown` so we're not restarting ray multiple times in a single isofit instance which should resolve the bug where core utilization was a fraction of what it could be